### PR TITLE
Cleanup

### DIFF
--- a/.storybook/presets.js
+++ b/.storybook/presets.js
@@ -1,1 +1,0 @@
-module.exports = ['@storybook/preset-typescript'];

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "@storybook/addon-actions": "^5.2.8",
     "@storybook/addon-links": "^5.2.8",
     "@storybook/addons": "^5.2.8",
-    "@storybook/preset-typescript": "^1.1.0",
     "@storybook/react": "^5.2.8",
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.3.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1559,11 +1559,6 @@
     pretty-hrtime "^1.0.3"
     regenerator-runtime "^0.12.1"
 
-"@storybook/preset-typescript@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@storybook/preset-typescript/-/preset-typescript-1.1.0.tgz#59821cee902d4c1bcda07e0276c958c495d330e4"
-  integrity sha512-V4Acf3XGzCFZQuX+91IL8LUbOC0Hs5/ZDZeo6YsuF6vTCIfzuX18PDw7Ph/0xJyL9yE45m8Fr7RA+c7JIwql1g==
-
 "@storybook/react@^5.2.8":
   version "5.2.8"
   resolved "https://registry.yarnpkg.com/@storybook/react/-/react-5.2.8.tgz#8d44c2d34caa1d7d748ec1fc9cf0fe2a88b001f9"


### PR DESCRIPTION
https://github.com/storybookjs/presets/tree/master/packages/preset-typescript のとおり入れたが、なくても動くし、どのみちTypeScript configをmanual setupするなら不要だったので、

- @storybook/preset-typescript
- .storybook/presets.js

を削除。